### PR TITLE
Disable Streamlit file watcher to avoid inotify limits

### DIFF
--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -2,3 +2,5 @@
 headless = true
 address = "0.0.0.0"
 port = 5000
+
+fileWatcherType = "none"


### PR DESCRIPTION
## Summary
- disable Streamlit file watcher to avoid inotify watch limit errors on Streamlit Community Cloud

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68b14ec06770832e9073745d7402bc84